### PR TITLE
FIX: Adds missing libpng12 step for Ubuntu installation guide

### DIFF
--- a/source/guides/installation/ubuntu/step2.html.md
+++ b/source/guides/installation/ubuntu/step2.html.md
@@ -37,6 +37,20 @@ for SplashKit to operate on Ubuntu.
     The pre-requisite packages will now be downloaded and installed. Wait
     for the installation process to finish before continuing to the next step.
 
+4. Install libpng12 (Ubuntu 17.04 users only)
+
+    If your [version of Ubuntu](/guides/installation/ubuntu/step1.html) is less than 17.04, you may skip this step.
+
+    To install libpng12, copy and paste the code below into your terminal, one line at a time.
+
+    ```bash
+    cd /tmp
+    wget http://mirrors.kernel.org/ubuntu/pool/main/libp/libpng/libpng12-0_1.2.54-1ubuntu1_amd64.deb
+    sudo dpkg -i libpng12-0_1.2.54-1ubuntu1_amd64.deb
+    cd -
+    ```
+
+
 Once you have completed this step, move on to the 
 [next step - Install SplashKit library](/guides/installation/ubuntu/step3.html).
 


### PR DESCRIPTION
This PR will:

* Add a missing sub-step for installing the libpng12 dependency on the Ubuntu installation guide

![screen-shot-2017-07-26-at-11 35 18-am](https://user-images.githubusercontent.com/7271686/28600667-bc8ce390-71f6-11e7-8480-49537184ffc0.jpg)
