### PR TITLE
LOOKS: Fixes padding on articles for responsive window sizes

### DIFF
--- a/source/guides/installation/index.html.erb
+++ b/source/guides/installation/index.html.erb
@@ -1,4 +1,4 @@
-<div style="text-align: center; padding: 4rem;">
+<div class="sk-text-center">
 
   <h1>Ubuntu</h1>
   <p class="lead">
@@ -14,6 +14,5 @@
   <p class="lead">
     Use the <%= link_to 'Windows Installation Guide', '/guides/installation/windows.html' %> to get started with SplashKit on Windows.
   </p>
-  
 
 </div>

--- a/source/stylesheets/partials/_article.scss
+++ b/source/stylesheets/partials/_article.scss
@@ -1,3 +1,12 @@
 .sk-article {
-     margin: 40px auto;
+     margin: 4rem auto 2.5em;
+
+     @include media-breakpoint-down(sm) {
+       padding: 1.5rem 1.5rem 0;
+       margin: 0 auto;
+     }
+}
+
+.sk-text-center {
+    text-align: center;
 }

--- a/source/stylesheets/partials/_footer.scss
+++ b/source/stylesheets/partials/_footer.scss
@@ -6,6 +6,11 @@ body > footer.sk-footer {
   font-size: 85%;
   color: $footer-color;
   background-color: $footer-background-color;
+  @include media-breakpoint-down(sm) {
+    padding: 1.25rem;
+    text-align: center;
+  }
+
   a {
     color: #fff;
     font-weight: 500;

--- a/source/stylesheets/partials/_main.scss
+++ b/source/stylesheets/partials/_main.scss
@@ -1,3 +1,6 @@
 main {
   padding-top: 0;
+  @include media-breakpoint-down(sm) {
+    padding-bottom: 1.5em;
+  }
 }


### PR DESCRIPTION
This PR:

- Removes inline CSS on the installation guide layout
- Replaces it with a reusable style class
- Improves the padding on guide articles to look better on smaller (mobile / table) screens
- Improves the padding and text justification in the footer on smaller screens

![before-after](https://user-images.githubusercontent.com/7271686/29860562-d66bfbe2-8da9-11e7-86c6-be8e2ba5b51f.jpg)

