### PR TITLE
Fix: #37 issue of broken link to audio example resources

### DIFF
--- a/source/articles/guides/2018-06-10-about-audio.html.md.erb
+++ b/source/articles/guides/2018-06-10-about-audio.html.md.erb
@@ -104,4 +104,4 @@ The following program code demonstrates the use of these audio features.
 
 <%= snippet "audio_basics", "articles/guides/audio/basic/" %>
 
-Download the [resources](/resources/audio/AboutResources.zip) for the above code.
+Download the [resources](/resources/audio/AudioResources.zip) for the above code.


### PR DESCRIPTION
Fixed broken link to audio example resources on Splashkit's website (#37)

Previously, the audio example resources on Splashkit's website were inaccessible due to a broken link. As a contributor, I took the initiative to fix the issue by updating the link to a new location where the resources are now hosted. This ensures that users of Splashkit can access the necessary resources for working with audio in their projects. By contributing to this open source project, I hope to improve the user experience for all members of the Splashkit community.