### PR TITLE
Bugfix: Windows Installation command

### DIFF
--- a/source/articles/installation/windows/step-2.html.md
+++ b/source/articles/installation/windows/step-2.html.md
@@ -15,7 +15,7 @@ Once you have MSYS2 installed, you can install the SplashKit library:
 
 1. In your MSYS2 Terminal, paste and run the following line
 
-    `bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh)`.
+    `bash <(curl -s https://raw.githubusercontent.com/splashkit/skm/master/install-scripts/skm-install.sh) .`
 
     This can also be found on the [SplashKit](http://www.splashkit.io) home page.
 


### PR DESCRIPTION
Trailing backtick was in the wrong place - copying the command and pasting into the MSYS window resulted in the error `bash: /dev/fd/63.: No such file or directory` . I've moved the backtick AFTER the dot - i.e. cwd and cut-n-paste now works.